### PR TITLE
1.4(a): Typo: Missing Closing Parenthesis

### DIFF
--- a/topics/linear-algebra.tex
+++ b/topics/linear-algebra.tex
@@ -436,7 +436,7 @@ eigenvalues $\lambda_i$ (which are not necessarily distinct).
 \begin{exenumerate}
 \item Use \exref{ex:eigenvalue-decomposition} to show that $\tr(\A)=\sum_i A_{ii} = \sum_i\lambda_i$. (You can use $\tr(\A\B)=\tr(\B\A)$.)
   \begin{solution}
-    Since $\tr(\A\B) = \tr(\B\A$ and $\A = \U\Lambdab \U^{-1}$
+    Since $\tr(\A\B) = \tr(\B\A)$ and $\A = \U\Lambdab \U^{-1}$
     \begin{align}
       \tr(\A)  &= \tr(\U\Lambdab \U^{-1}) \\
                &= \tr(\Lambdab \U^{-1}\U) \\


### PR DESCRIPTION
- In 1.4 (a): tr(AB) = tr(BA) was missing a closing parenthesis